### PR TITLE
FIX Add OnSetCode on our mocked config

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -52,6 +52,7 @@ impl system::Config for Test {
     type OnKilledAccount = ();
     type SystemWeightInfo = ();
     type SS58Prefix = SS58Prefix;
+    type OnSetCode = ();
 }
 
 parameter_types! {


### PR DESCRIPTION
Following the @gavofyork work on [this](https://github.com/paritytech/substrate/pull/8496), we need to change our mocked unit tests Config.